### PR TITLE
Feature/task3 add follow service

### DIFF
--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -2,6 +2,7 @@ package repository
 
 import "context"
 
+//go:generate mockery --name=FollowRepository --output=../../mocks --outpkg=mocks --case=underscore --with-expecter
 type FollowRepository interface {
 	Create(ctx context.Context, followerID, followeeID int64) error
 	Delete(ctx context.Context, followerID, followeeID int64) error

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -5,6 +5,7 @@ import "context"
 type FollowRepository interface {
 	Create(ctx context.Context, followerID, followeeID int64) error
 	Delete(ctx context.Context, followerID, followeeID int64) error
+	Exists(ctx context.Context, followerID, followeeID int64) (bool, error)
 	GetFollowers(ctx context.Context, followeeID int64) ([]int64, error)
 	GetFollowees(ctx context.Context, followerID int64) ([]int64, error)
 }

--- a/internal/repository/postgres/repository.go
+++ b/internal/repository/postgres/repository.go
@@ -17,7 +17,7 @@ func NewFollowRepository(db PgDB, log *logger.Logger) *Repository {
 	return &Repository{db: db, log: log}
 }
 
-func (r Repository) Create(ctx context.Context, followerID, followeeID int64) error {
+func (r *Repository) Create(ctx context.Context, followerID, followeeID int64) error {
 	r.log.Info("Creating follow relation", slog.Int64("follower_id", followerID), slog.Int64("followee_id", followeeID))
 
 	if followerID == followeeID {
@@ -52,7 +52,7 @@ func (r Repository) Create(ctx context.Context, followerID, followeeID int64) er
 	return nil
 }
 
-func (r Repository) Delete(ctx context.Context, followerID, followeeID int64) error {
+func (r *Repository) Delete(ctx context.Context, followerID, followeeID int64) error {
 	r.log.Info("Deleting follow relation", slog.Int64("follower_id", followerID), slog.Int64("followee_id", followeeID))
 
 	args := pgx.NamedArgs{
@@ -88,7 +88,7 @@ func (r Repository) Delete(ctx context.Context, followerID, followeeID int64) er
 	return nil
 }
 
-func (r Repository) GetFollowers(ctx context.Context, followeeID int64) ([]int64, error) {
+func (r *Repository) GetFollowers(ctx context.Context, followeeID int64) ([]int64, error) {
 	r.log.Info("Getting followers", slog.Int64("followee_id", followeeID))
 
 	args := pgx.NamedArgs{
@@ -135,7 +135,7 @@ func (r Repository) GetFollowers(ctx context.Context, followeeID int64) ([]int64
 	return followers, nil
 }
 
-func (r Repository) GetFollowees(ctx context.Context, followerID int64) ([]int64, error) {
+func (r *Repository) GetFollowees(ctx context.Context, followerID int64) ([]int64, error) {
 	r.log.Info("Getting followees", slog.Int64("follower_id", followerID))
 
 	args := pgx.NamedArgs{
@@ -182,7 +182,7 @@ func (r Repository) GetFollowees(ctx context.Context, followerID int64) ([]int64
 	return followees, nil
 }
 
-func (r Repository) Exists(ctx context.Context, followerID, followeeID int64) (bool, error) {
+func (r *Repository) Exists(ctx context.Context, followerID, followeeID int64) (bool, error) {
 	r.log.Info("Checking if follow relation exists",
 		slog.Int64("follower_id", followerID),
 		slog.Int64("followee_id", followeeID))

--- a/internal/service/interface.go
+++ b/internal/service/interface.go
@@ -1,1 +1,10 @@
 package service
+
+import "context"
+
+type FollowService interface {
+	Follow(ctx context.Context, followerID, followeeID int64) error
+	Unfollow(ctx context.Context, followerID, followeeID int64) error
+	GetFollowers(ctx context.Context, followeeID int64) ([]int64, error)
+	GetFollowees(ctx context.Context, followerID int64) ([]int64, error)
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,1 +1,99 @@
 package service
+
+import (
+	"context"
+	"log/slog"
+	"pinstack-relation-service/internal/custom_errors"
+	"pinstack-relation-service/internal/logger"
+	"pinstack-relation-service/internal/repository"
+)
+
+type Service struct {
+	followRepo repository.FollowRepository
+	log        *logger.Logger
+}
+
+func NewFollowService(log *logger.Logger, followRepo repository.FollowRepository) *Service {
+	return &Service{
+		log:        log,
+		followRepo: followRepo,
+	}
+}
+
+func (s *Service) Follow(ctx context.Context, followerID, followeeID int64) error {
+	s.log.Info("Follow request received", slog.Int64("followerID", followerID), slog.Int64("followeeID", followeeID))
+
+	if followerID == followeeID {
+		return custom_errors.ErrSelfFollow
+	}
+
+	exists, err := s.followRepo.Exists(ctx, followerID, followeeID)
+	if err != nil {
+		s.log.Error("Error checking follow existence", slog.String("error", err.Error()))
+		return err
+	}
+	if exists {
+		return custom_errors.ErrFollowRelationExists
+	}
+
+	err = s.followRepo.Create(ctx, followerID, followeeID)
+	if err != nil {
+		s.log.Error("Error creating follow relationship", slog.String("error", err.Error()))
+		return err
+	}
+
+	s.log.Info("Follow relationship created successfully", slog.Int64("followerID", followerID), slog.Int64("followeeID", followeeID))
+	return nil
+}
+
+func (s *Service) Unfollow(ctx context.Context, followerID, followeeID int64) error {
+	s.log.Info("Unfollow request received", slog.Int64("followerID", followerID), slog.Int64("followeeID", followeeID))
+
+	if followerID == followeeID {
+		return custom_errors.ErrSelfFollow
+	}
+
+	exists, err := s.followRepo.Exists(ctx, followerID, followeeID)
+	if err != nil {
+		s.log.Error("Error checking follow existence", slog.String("error", err.Error()))
+		return err
+	}
+	if !exists {
+		return custom_errors.ErrFollowRelationNotFound
+	}
+
+	err = s.followRepo.Delete(ctx, followerID, followeeID)
+	if err != nil {
+		s.log.Error("Error deleting follow relationship", slog.String("error", err.Error()))
+		return err
+	}
+
+	s.log.Info("Follow relationship deleted successfully", slog.Int64("followerID", followerID), slog.Int64("followeeID", followeeID))
+	return nil
+}
+
+func (s *Service) GetFollowers(ctx context.Context, followeeID int64) ([]int64, error) {
+	s.log.Info("GetFollowers request received", slog.Int64("followeeID", followeeID))
+
+	followers, err := s.followRepo.GetFollowers(ctx, followeeID)
+	if err != nil {
+		s.log.Error("Error getting followers", slog.String("error", err.Error()))
+		return nil, err
+	}
+
+	s.log.Info("Followers retrieved successfully", slog.Int64("followeeID", followeeID), slog.Int("count", len(followers)))
+	return followers, nil
+}
+
+func (s *Service) GetFollowees(ctx context.Context, followerID int64) ([]int64, error) {
+	s.log.Info("GetFollowees request received", slog.Int64("followerID", followerID))
+
+	followees, err := s.followRepo.GetFollowees(ctx, followerID)
+	if err != nil {
+		s.log.Error("Error getting followees", slog.String("error", err.Error()))
+		return nil, err
+	}
+
+	s.log.Info("Followees retrieved successfully", slog.Int64("followerID", followerID), slog.Int("count", len(followees)))
+	return followees, nil
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,305 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"pinstack-relation-service/internal/custom_errors"
+	"pinstack-relation-service/internal/logger"
+	"pinstack-relation-service/mocks"
+)
+
+func TestService_Follow(t *testing.T) {
+	tests := []struct {
+		name        string
+		followerID  int64
+		followeeID  int64
+		mockSetup   func(*mocks.FollowRepository)
+		wantErr     bool
+		expectedErr error
+	}{
+		{
+			name:       "successful follow",
+			followerID: 1,
+			followeeID: 2,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("Exists", mock.Anything, int64(1), int64(2)).Return(false, nil)
+				repo.On("Create", mock.Anything, int64(1), int64(2)).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "self follow error",
+			followerID:  1,
+			followeeID:  1,
+			mockSetup:   func(repo *mocks.FollowRepository) {},
+			wantErr:     true,
+			expectedErr: custom_errors.ErrSelfFollow,
+		},
+		{
+			name:       "relationship already exists",
+			followerID: 1,
+			followeeID: 2,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("Exists", mock.Anything, int64(1), int64(2)).Return(true, nil)
+			},
+			wantErr:     true,
+			expectedErr: custom_errors.ErrFollowRelationExists,
+		},
+		{
+			name:       "exists check error",
+			followerID: 1,
+			followeeID: 2,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("Exists", mock.Anything, int64(1), int64(2)).Return(false, errors.New("db error"))
+			},
+			wantErr: true,
+		},
+		{
+			name:       "create relationship error",
+			followerID: 1,
+			followeeID: 2,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("Exists", mock.Anything, int64(1), int64(2)).Return(false, nil)
+				repo.On("Create", mock.Anything, int64(1), int64(2)).Return(custom_errors.ErrFollowRelationCreateFail)
+			},
+			wantErr:     true,
+			expectedErr: custom_errors.ErrFollowRelationCreateFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := mocks.NewFollowRepository(t)
+			log := logger.New("dev")
+
+			if tt.mockSetup != nil {
+				tt.mockSetup(mockRepo)
+			}
+
+			service := NewFollowService(log, mockRepo)
+			err := service.Follow(context.Background(), tt.followerID, tt.followeeID)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestService_Unfollow(t *testing.T) {
+	tests := []struct {
+		name        string
+		followerID  int64
+		followeeID  int64
+		mockSetup   func(*mocks.FollowRepository)
+		wantErr     bool
+		expectedErr error
+	}{
+		{
+			name:       "successful unfollow",
+			followerID: 1,
+			followeeID: 2,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("Exists", mock.Anything, int64(1), int64(2)).Return(true, nil)
+				repo.On("Delete", mock.Anything, int64(1), int64(2)).Return(nil)
+			},
+			wantErr: false,
+		},
+		{
+			name:        "self unfollow error",
+			followerID:  1,
+			followeeID:  1,
+			mockSetup:   func(repo *mocks.FollowRepository) {},
+			wantErr:     true,
+			expectedErr: custom_errors.ErrSelfFollow,
+		},
+		{
+			name:       "relationship doesn't exist",
+			followerID: 1,
+			followeeID: 2,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("Exists", mock.Anything, int64(1), int64(2)).Return(false, nil)
+			},
+			wantErr:     true,
+			expectedErr: custom_errors.ErrFollowRelationNotFound,
+		},
+		{
+			name:       "exists check error",
+			followerID: 1,
+			followeeID: 2,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("Exists", mock.Anything, int64(1), int64(2)).Return(false, errors.New("db error"))
+			},
+			wantErr: true,
+		},
+		{
+			name:       "delete relationship error",
+			followerID: 1,
+			followeeID: 2,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("Exists", mock.Anything, int64(1), int64(2)).Return(true, nil)
+				repo.On("Delete", mock.Anything, int64(1), int64(2)).Return(custom_errors.ErrFollowRelationDeleteFail)
+			},
+			wantErr:     true,
+			expectedErr: custom_errors.ErrFollowRelationDeleteFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := mocks.NewFollowRepository(t)
+			log := logger.New("dev")
+
+			if tt.mockSetup != nil {
+				tt.mockSetup(mockRepo)
+			}
+
+			service := NewFollowService(log, mockRepo)
+			err := service.Unfollow(context.Background(), tt.followerID, tt.followeeID)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestService_GetFollowers(t *testing.T) {
+	tests := []struct {
+		name        string
+		followeeID  int64
+		mockSetup   func(*mocks.FollowRepository)
+		want        []int64
+		wantErr     bool
+		expectedErr error
+	}{
+		{
+			name:       "successful get followers",
+			followeeID: 1,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("GetFollowers", mock.Anything, int64(1)).Return([]int64{2, 3, 4}, nil)
+			},
+			want:    []int64{2, 3, 4},
+			wantErr: false,
+		},
+		{
+			name:       "empty followers list",
+			followeeID: 1,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("GetFollowers", mock.Anything, int64(1)).Return([]int64{}, nil)
+			},
+			want:    []int64{},
+			wantErr: false,
+		},
+		{
+			name:       "database error",
+			followeeID: 1,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("GetFollowers", mock.Anything, int64(1)).Return(nil, custom_errors.ErrDatabaseQuery)
+			},
+			want:        nil,
+			wantErr:     true,
+			expectedErr: custom_errors.ErrDatabaseQuery,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := mocks.NewFollowRepository(t)
+			log := logger.New("dev")
+
+			if tt.mockSetup != nil {
+				tt.mockSetup(mockRepo)
+			}
+
+			service := NewFollowService(log, mockRepo)
+			got, err := service.GetFollowers(context.Background(), tt.followeeID)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestService_GetFollowees(t *testing.T) {
+	tests := []struct {
+		name        string
+		followerID  int64
+		mockSetup   func(*mocks.FollowRepository)
+		want        []int64
+		wantErr     bool
+		expectedErr error
+	}{
+		{
+			name:       "successful get followees",
+			followerID: 1,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("GetFollowees", mock.Anything, int64(1)).Return([]int64{2, 3, 4}, nil)
+			},
+			want:    []int64{2, 3, 4},
+			wantErr: false,
+		},
+		{
+			name:       "empty followees list",
+			followerID: 1,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("GetFollowees", mock.Anything, int64(1)).Return([]int64{}, nil)
+			},
+			want:    []int64{},
+			wantErr: false,
+		},
+		{
+			name:       "database error",
+			followerID: 1,
+			mockSetup: func(repo *mocks.FollowRepository) {
+				repo.On("GetFollowees", mock.Anything, int64(1)).Return(nil, custom_errors.ErrDatabaseQuery)
+			},
+			want:        nil,
+			wantErr:     true,
+			expectedErr: custom_errors.ErrDatabaseQuery,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := mocks.NewFollowRepository(t)
+			log := logger.New("dev")
+
+			if tt.mockSetup != nil {
+				tt.mockSetup(mockRepo)
+			}
+
+			service := NewFollowService(log, mockRepo)
+			got, err := service.GetFollowees(context.Background(), tt.followerID)
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Этот pull request добавляет новый FollowService и расширяет функциональность FollowRepository для управления отношениями подписок. Основные изменения включают в себя реализацию интерфейса FollowService, добавление метода Exists в репозиторий и создание подробных модульных тестов для сервиса и репозитория.
Улучшения репозитория:

    Добавлен метод Exists в FollowRepository для проверки существования отношения подписки. Включает логику запроса к базе данных и обработку ошибок. (internal/repository/interface.go, internal/repository/postgres/repository.go)
    Все методы в FollowRepository теперь используют указатели в качестве получателей (pointer receivers) для единообразия и предотвращения лишнего копирования объекта репозитория. (internal/repository/postgres/repository.go)

Реализация сервиса:

    Введён интерфейс FollowService с методами для управления подписками (Follow, Unfollow, GetFollowers, GetFollowees). (internal/service/interface.go)
    Реализован FollowService в новой структуре Service, которая использует FollowRepository для работы с данными и добавляет бизнес-логику для валидации и обработки ошибок. (internal/service/service.go)

Улучшения тестирования:

    Добавлены модульные тесты для нового метода Exists в FollowRepository, покрывающие успешные проверки, несуществующие связи и ошибки базы данных. (internal/repository/postgres/repository_test.go)
    Созданы подробные модульные тесты для всех методов FollowService, которые проверяют как успешные сценарии, так и различные ошибки (например, попытка подписаться на самого себя, уже существующая связь, ошибки базы данных). (internal/service/service_test.go)
