### PR TITLE
Feature / task5 add pagination support

### DIFF
--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -7,6 +7,6 @@ type FollowRepository interface {
 	Create(ctx context.Context, followerID, followeeID int64) error
 	Delete(ctx context.Context, followerID, followeeID int64) error
 	Exists(ctx context.Context, followerID, followeeID int64) (bool, error)
-	GetFollowers(ctx context.Context, followeeID int64) ([]int64, error)
-	GetFollowees(ctx context.Context, followerID int64) ([]int64, error)
+	GetFollowers(ctx context.Context, followeeID int64, limit, offset int32) ([]int64, error)
+	GetFollowees(ctx context.Context, followerID int64, limit, offset int32) ([]int64, error)
 }

--- a/internal/repository/postgres/repository.go
+++ b/internal/repository/postgres/repository.go
@@ -88,17 +88,21 @@ func (r *Repository) Delete(ctx context.Context, followerID, followeeID int64) e
 	return nil
 }
 
-func (r *Repository) GetFollowers(ctx context.Context, followeeID int64) ([]int64, error) {
+func (r *Repository) GetFollowers(ctx context.Context, followeeID int64, limit, offset int32) ([]int64, error) {
 	r.log.Info("Getting followers", slog.Int64("followee_id", followeeID))
 
 	args := pgx.NamedArgs{
 		"followee_id": followeeID,
+		"limit":       limit,
+		"offset":      offset,
 	}
 
 	query := `
 		SELECT follower_id 
 		FROM followers 
 		WHERE followee_id = @followee_id
+		ORDER BY created_at DESC
+		LIMIT @limit OFFSET @offset
 	`
 
 	rows, err := r.db.Query(ctx, query, args)
@@ -135,17 +139,21 @@ func (r *Repository) GetFollowers(ctx context.Context, followeeID int64) ([]int6
 	return followers, nil
 }
 
-func (r *Repository) GetFollowees(ctx context.Context, followerID int64) ([]int64, error) {
+func (r *Repository) GetFollowees(ctx context.Context, followerID int64, limit, offset int32) ([]int64, error) {
 	r.log.Info("Getting followees", slog.Int64("follower_id", followerID))
 
 	args := pgx.NamedArgs{
 		"follower_id": followerID,
+		"limit":       limit,
+		"offset":      offset,
 	}
 
 	query := `
 		SELECT followee_id 
 		FROM followers 
 		WHERE follower_id = @follower_id
+		ORDER BY created_at DESC
+		LIMIT @limit OFFSET @offset
 	`
 
 	rows, err := r.db.Query(ctx, query, args)

--- a/internal/service/interface.go
+++ b/internal/service/interface.go
@@ -5,6 +5,6 @@ import "context"
 type FollowService interface {
 	Follow(ctx context.Context, followerID, followeeID int64) error
 	Unfollow(ctx context.Context, followerID, followeeID int64) error
-	GetFollowers(ctx context.Context, followeeID int64) ([]int64, error)
-	GetFollowees(ctx context.Context, followerID int64) ([]int64, error)
+	GetFollowers(ctx context.Context, followeeID int64, limit, page int32) ([]int64, error)
+	GetFollowees(ctx context.Context, followerID int64, limit, page int32) ([]int64, error)
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -8,6 +8,8 @@ import (
 	"pinstack-relation-service/internal/repository"
 )
 
+const defaultLimit = 20
+
 type Service struct {
 	followRepo repository.FollowRepository
 	log        *logger.Logger
@@ -72,10 +74,16 @@ func (s *Service) Unfollow(ctx context.Context, followerID, followeeID int64) er
 	return nil
 }
 
-func (s *Service) GetFollowers(ctx context.Context, followeeID int64) ([]int64, error) {
+func (s *Service) GetFollowers(ctx context.Context, followeeID int64, limit, page int32) ([]int64, error) {
 	s.log.Info("GetFollowers request received", slog.Int64("followeeID", followeeID))
-
-	followers, err := s.followRepo.GetFollowers(ctx, followeeID)
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+	followers, err := s.followRepo.GetFollowers(ctx, followeeID, limit, offset)
 	if err != nil {
 		s.log.Error("Error getting followers", slog.String("error", err.Error()))
 		return nil, err
@@ -85,10 +93,16 @@ func (s *Service) GetFollowers(ctx context.Context, followeeID int64) ([]int64, 
 	return followers, nil
 }
 
-func (s *Service) GetFollowees(ctx context.Context, followerID int64) ([]int64, error) {
+func (s *Service) GetFollowees(ctx context.Context, followerID int64, limit, page int32) ([]int64, error) {
 	s.log.Info("GetFollowees request received", slog.Int64("followerID", followerID))
-
-	followees, err := s.followRepo.GetFollowees(ctx, followerID)
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+	followees, err := s.followRepo.GetFollowees(ctx, followerID, limit, offset)
 	if err != nil {
 		s.log.Error("Error getting followees", slog.String("error", err.Error()))
 		return nil, err


### PR DESCRIPTION
This pull request introduces pagination support for the `GetFollowers` and `GetFollowees` methods in the repository and service layers, along with corresponding updates to tests. The changes ensure that these methods now accept `limit` and `page` parameters, enabling efficient retrieval of paginated results.

### Repository Layer Updates:
* Modified `GetFollowers` and `GetFollowees` methods in `internal/repository/interface.go` to include `limit` and `offset` parameters, replacing the previous versions without pagination.
* Updated SQL queries in `internal/repository/postgres/repository.go` to use `LIMIT` and `OFFSET` for pagination, and added ordering by `created_at DESC`. [[1]](diffhunk://#diff-e88ed7a8f18a208f230584dc9202e5ccd76bde6d3fa44ebc7a8a3beafb96d60dL91-R105) [[2]](diffhunk://#diff-e88ed7a8f18a208f230584dc9202e5ccd76bde6d3fa44ebc7a8a3beafb96d60dL138-R156)

### Service Layer Updates:
* Added `limit` and `page` parameters to `GetFollowers` and `GetFollowees` methods in `internal/service/interface.go` and `internal/service/service.go`. Default values are applied for invalid inputs. [[1]](diffhunk://#diff-f29c648606a8a14d18cdae2b403c654bd0613a72aa43fd03e641aa08623dfa4aL8-R9) [[2]](diffhunk://#diff-e977aef3a61407d38b134a73df7978004343a347ee0b5c8cc69a57b31624e2d0L75-R86) [[3]](diffhunk://#diff-e977aef3a61407d38b134a73df7978004343a347ee0b5c8cc69a57b31624e2d0L88-R105)
* Introduced a `defaultLimit` constant in `internal/service/service.go` for fallback pagination.

### Test Enhancements:
* Updated test cases in `internal/repository/postgres/repository_test.go` and `internal/service/service_test.go` to validate pagination logic, including scenarios with default values, custom pagination, and edge cases. [[1]](diffhunk://#diff-ea1a75c294d4c40ecde54347e7bb7c2e89e949e7013c39f56cbe8381d6f0c18fR192-R244) [[2]](diffhunk://#diff-d9e77edcb9ff0e805cf19ae708cd5f642b2052d65ede047561b0df255b8bed65R185-R280)
* Mocked repository calls to verify correct `limit` and `offset` values in queries. [[1]](diffhunk://#diff-ea1a75c294d4c40ecde54347e7bb7c2e89e949e7013c39f56cbe8381d6f0c18fL264-R301) [[2]](diffhunk://#diff-d9e77edcb9ff0e805cf19ae708cd5f642b2052d65ede047561b0df255b8bed65L230-R298)