### PR TITLE
feat: add Prometheus metrics server configuration and implementation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	EventTypes  EventTypes
 	Kafka       Kafka
 	Outbox      OutboxConfig
+	Prometheus  Prometheus
 }
 
 type GRPCServer struct {
@@ -61,6 +62,11 @@ type OutboxConfig struct {
 	BatchSize      int
 }
 
+type Prometheus struct {
+	Address string
+	Port    int
+}
+
 func (o OutboxConfig) TickInterval() time.Duration {
 	return time.Duration(o.TickIntervalMs) * time.Millisecond
 }
@@ -103,6 +109,9 @@ func MustLoad() *Config {
 	viper.SetDefault("outbox.concurrency", 10)
 	viper.SetDefault("outbox.tick_interval_ms", 2000)
 	viper.SetDefault("outbox.batch_size", 100)
+
+	viper.SetDefault("prometheus.address", "0.0.0.0")
+	viper.SetDefault("prometheus.port", 9104)
 
 	if err := viper.ReadInConfig(); err != nil {
 		log.Printf("Error reading config file: %s", err)
@@ -148,6 +157,10 @@ func MustLoad() *Config {
 			Concurrency:    viper.GetInt("outbox.concurrency"),
 			TickIntervalMs: viper.GetInt("outbox.tick_interval_ms"),
 			BatchSize:      viper.GetInt("outbox.batch_size"),
+		},
+		Prometheus: Prometheus{
+			Address: viper.GetString("prometheus.address"),
+			Port:    viper.GetInt("prometheus.port"),
 		},
 	}
 

--- a/config/example.yml
+++ b/config/example.yml
@@ -37,3 +37,7 @@ outbox:
   concurrency: 10
   tick_interval_ms: 2000
   batch_size: 100
+
+prometheus:
+  address: "0.0.0.0"
+  port: 9104

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.18.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/jackc/pgx/v5 v5.5.4
+	github.com/prometheus/client_golang v1.17.0
 	github.com/soloda1/pinstack-proto-definitions v0.1.17
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
@@ -15,12 +16,15 @@ require (
 )
 
 require (
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -28,9 +32,13 @@ require (
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.5.0 // indirect
+	github.com/prometheus/common v0.44.0 // indirect
+	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,7 @@ golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
 golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
This pull request introduces Prometheus metrics integration into the project. It includes changes to add a Prometheus metrics server, update the configuration files, and include necessary dependencies. The most important changes are grouped into themes below.

### Prometheus Metrics Integration:

* Added Prometheus metrics server initialization in `cmd/server/main.go`, including the `metricsServer` setup, `/metrics` endpoint, and graceful shutdown handling.
* Updated `config/config.go` to include a new `Prometheus` configuration struct and default values for Prometheus server address and port. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R65-R69) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R113-R115) [[3]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R161-R164)
* Modified `config/example.yml` to include example Prometheus configuration settings.

### Dependency Updates:

* Added `github.com/prometheus/client_golang` and other Prometheus-related packages to `go.mod` for metrics functionality.