### PR TITLE
Refactor/task31 get followers followees

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/jackc/pgx/v5 v5.5.4
 	github.com/prometheus/client_golang v1.17.0
-	github.com/soloda1/pinstack-proto-definitions v0.1.17
+	github.com/soloda1/pinstack-proto-definitions v0.1.19
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	google.golang.org/grpc v1.73.0

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
-github.com/soloda1/pinstack-proto-definitions v0.1.17 h1:c6evxxHF4FaOtbcjWXBSxVDxnpCskDpiFQJkNEgPUBw=
-github.com/soloda1/pinstack-proto-definitions v0.1.17/go.mod h1:Jl7Cv/0eQDLtxI5HdRANm6HYbSjX1x97Za4XRUySwrM=
+github.com/soloda1/pinstack-proto-definitions v0.1.19 h1:TRBG1HJcBvUqFy8u5OdF5z4ZX5YzxLDxhOKV+CFUoXs=
+github.com/soloda1/pinstack-proto-definitions v0.1.19/go.mod h1:Jl7Cv/0eQDLtxI5HdRANm6HYbSjX1x97Za4XRUySwrM=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=

--- a/internal/delivery/grpc/get_followees_handler_test.go
+++ b/internal/delivery/grpc/get_followees_handler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	follow_grpc "pinstack-relation-service/internal/delivery/grpc"
+	"pinstack-relation-service/internal/model"
+	"pinstack-relation-service/internal/utils"
 	"testing"
 
 	"github.com/go-playground/validator/v10"
@@ -26,7 +28,8 @@ func TestGetFolloweesHandler_GetFollowees(t *testing.T) {
 		wantErr        bool
 		expectedCode   codes.Code
 		expectedErrMsg string
-		expectedIDs    []int64
+		expectedUsers  []*model.User
+		expectedTotal  int64
 	}{
 		{
 			name: "successful get followees",
@@ -36,11 +39,21 @@ func TestGetFolloweesHandler_GetFollowees(t *testing.T) {
 				Page:       1,
 			},
 			mockSetup: func(mockService *mocks.FollowService) {
+				users := []*model.User{
+					{ID: 2, Username: "user2", AvatarURL: utils.StringPtr("avatar2.jpg")},
+					{ID: 3, Username: "user3", AvatarURL: nil},
+					{ID: 4, Username: "user4", AvatarURL: utils.StringPtr("avatar4.jpg")},
+				}
 				mockService.On("GetFollowees", mock.Anything, int64(1), int32(10), int32(1)).
-					Return([]int64{2, 3, 4}, nil)
+					Return(users, int64(15), nil)
 			},
-			wantErr:     false,
-			expectedIDs: []int64{2, 3, 4},
+			wantErr: false,
+			expectedUsers: []*model.User{
+				{ID: 2, Username: "user2", AvatarURL: utils.StringPtr("avatar2.jpg")},
+				{ID: 3, Username: "user3", AvatarURL: nil},
+				{ID: 4, Username: "user4", AvatarURL: utils.StringPtr("avatar4.jpg")},
+			},
+			expectedTotal: 15,
 		},
 		{
 			name: "empty result",
@@ -51,10 +64,11 @@ func TestGetFolloweesHandler_GetFollowees(t *testing.T) {
 			},
 			mockSetup: func(mockService *mocks.FollowService) {
 				mockService.On("GetFollowees", mock.Anything, int64(1), int32(10), int32(1)).
-					Return([]int64{}, nil)
+					Return([]*model.User{}, int64(0), nil)
 			},
-			wantErr:     false,
-			expectedIDs: []int64{},
+			wantErr:       false,
+			expectedUsers: []*model.User{},
+			expectedTotal: 0,
 		},
 		{
 			name: "validation error - follower ID zero",
@@ -113,7 +127,7 @@ func TestGetFolloweesHandler_GetFollowees(t *testing.T) {
 			},
 			mockSetup: func(mockService *mocks.FollowService) {
 				mockService.On("GetFollowees", mock.Anything, int64(1), int32(10), int32(1)).
-					Return([]int64{}, custom_errors.ErrUserNotFound)
+					Return([]*model.User{}, int64(0), custom_errors.ErrUserNotFound)
 			},
 			wantErr:        true,
 			expectedCode:   codes.NotFound,
@@ -128,7 +142,7 @@ func TestGetFolloweesHandler_GetFollowees(t *testing.T) {
 			},
 			mockSetup: func(mockService *mocks.FollowService) {
 				mockService.On("GetFollowees", mock.Anything, int64(1), int32(10), int32(1)).
-					Return([]int64{}, custom_errors.ErrDatabaseQuery)
+					Return([]*model.User{}, int64(0), custom_errors.ErrDatabaseQuery)
 			},
 			wantErr:        true,
 			expectedCode:   codes.Internal,
@@ -143,7 +157,7 @@ func TestGetFolloweesHandler_GetFollowees(t *testing.T) {
 			},
 			mockSetup: func(mockService *mocks.FollowService) {
 				mockService.On("GetFollowees", mock.Anything, int64(1), int32(10), int32(1)).
-					Return([]int64{}, errors.New("unexpected error"))
+					Return([]*model.User{}, int64(0), errors.New("unexpected error"))
 			},
 			wantErr:        true,
 			expectedCode:   codes.Internal,
@@ -173,8 +187,18 @@ func TestGetFolloweesHandler_GetFollowees(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, resp)
-				assert.Equal(t, len(tt.expectedIDs), len(resp.FolloweeIds))
-				assert.ElementsMatch(t, tt.expectedIDs, resp.FolloweeIds)
+				assert.Equal(t, len(tt.expectedUsers), len(resp.Followees))
+				assert.Equal(t, tt.expectedTotal, resp.Total)
+
+				for i, expectedUser := range tt.expectedUsers {
+					assert.Equal(t, expectedUser.ID, resp.Followees[i].FollowerId)
+					assert.Equal(t, expectedUser.Username, resp.Followees[i].Username)
+					if expectedUser.AvatarURL != nil {
+						assert.Equal(t, *expectedUser.AvatarURL, *resp.Followees[i].AvatarUrl)
+					} else {
+						assert.Nil(t, resp.Followees[i].AvatarUrl)
+					}
+				}
 			}
 
 			mockService.AssertExpectations(t)

--- a/internal/repository/interface.go
+++ b/internal/repository/interface.go
@@ -10,6 +10,6 @@ type FollowRepository interface {
 	Create(ctx context.Context, followerID, followeeID int64) (model.Follower, error)
 	Delete(ctx context.Context, followerID, followeeID int64) error
 	Exists(ctx context.Context, followerID, followeeID int64) (bool, error)
-	GetFollowers(ctx context.Context, followeeID int64, limit, offset int32) ([]int64, error)
-	GetFollowees(ctx context.Context, followerID int64, limit, offset int32) ([]int64, error)
+	GetFollowers(ctx context.Context, followeeID int64, limit, offset int32) ([]int64, int64, error)
+	GetFollowees(ctx context.Context, followerID int64, limit, offset int32) ([]int64, int64, error)
 }

--- a/internal/service/interface.go
+++ b/internal/service/interface.go
@@ -1,11 +1,14 @@
 package service
 
-import "context"
+import (
+	"context"
+	"pinstack-relation-service/internal/model"
+)
 
 //go:generate mockery --name=FollowService --output=../../mocks --outpkg=mocks --case=underscore --with-expecter
 type FollowService interface {
 	Follow(ctx context.Context, followerID, followeeID int64) error
 	Unfollow(ctx context.Context, followerID, followeeID int64) error
-	GetFollowers(ctx context.Context, followeeID int64, limit, page int32) ([]int64, error)
-	GetFollowees(ctx context.Context, followerID int64, limit, page int32) ([]int64, error)
+	GetFollowers(ctx context.Context, followeeID int64, limit, page int32) ([]*model.User, int64, error)
+	GetFollowees(ctx context.Context, followerID int64, limit, page int32) ([]*model.User, int64, error)
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -140,7 +140,7 @@ func (s *Service) Unfollow(ctx context.Context, followerID, followeeID int64) er
 	return nil
 }
 
-func (s *Service) GetFollowers(ctx context.Context, followeeID int64, limit, page int32) ([]int64, error) {
+func (s *Service) GetFollowers(ctx context.Context, followeeID int64, limit, page int32) ([]*model.User, int64, error) {
 	s.log.Info("GetFollowers request received", slog.Int64("followeeID", followeeID))
 	_, err := s.userClient.GetUser(ctx, followeeID)
 	if err != nil {
@@ -148,23 +148,35 @@ func (s *Service) GetFollowers(ctx context.Context, followeeID int64, limit, pag
 		switch {
 		case errors.Is(err, custom_errors.ErrUserNotFound):
 			s.log.Debug("User not found in GetFollowers", slog.Int64("followeeID", followeeID), slog.String("error", err.Error()))
-			return nil, custom_errors.ErrUserNotFound
+			return nil, 0, custom_errors.ErrUserNotFound
 		default:
-			return nil, err
+			return nil, 0, err
 		}
 	}
 	limit, offset := utils.SetPaginationDefaults(limit, page)
-	followers, err := s.followRepo.GetFollowers(ctx, followeeID, limit, offset)
+	followerIDs, total, err := s.followRepo.GetFollowers(ctx, followeeID, limit, offset)
 	if err != nil {
 		s.log.Error("Error getting followers", slog.String("error", err.Error()))
-		return nil, err
+		return nil, 0, err
 	}
 
-	s.log.Info("Followers retrieved successfully", slog.Int64("followeeID", followeeID), slog.Int("count", len(followers)))
-	return followers, nil
+	// Получаем информацию о пользователях по их ID
+	followers := make([]*model.User, 0, len(followerIDs))
+	for _, followerID := range followerIDs {
+		user, err := s.userClient.GetUser(ctx, followerID)
+		if err != nil {
+			s.log.Error("Failed to get follower user", slog.Int64("followerID", followerID), slog.String("error", err.Error()))
+			// Пропускаем пользователей, которых не удалось получить
+			continue
+		}
+		followers = append(followers, user)
+	}
+
+	s.log.Info("Followers retrieved successfully", slog.Int64("followeeID", followeeID), slog.Int("count", len(followers)), slog.Int64("total", total))
+	return followers, total, nil
 }
 
-func (s *Service) GetFollowees(ctx context.Context, followerID int64, limit, page int32) ([]int64, error) {
+func (s *Service) GetFollowees(ctx context.Context, followerID int64, limit, page int32) ([]*model.User, int64, error) {
 	s.log.Info("GetFollowees request received", slog.Int64("followerID", followerID))
 	_, err := s.userClient.GetUser(ctx, followerID)
 	if err != nil {
@@ -172,18 +184,30 @@ func (s *Service) GetFollowees(ctx context.Context, followerID int64, limit, pag
 		switch {
 		case errors.Is(err, custom_errors.ErrUserNotFound):
 			s.log.Debug("User not found in GetFollowees", slog.Int64("followerID", followerID), slog.String("error", err.Error()))
-			return nil, custom_errors.ErrUserNotFound
+			return nil, 0, custom_errors.ErrUserNotFound
 		default:
-			return nil, err
+			return nil, 0, err
 		}
 	}
 	limit, offset := utils.SetPaginationDefaults(limit, page)
-	followees, err := s.followRepo.GetFollowees(ctx, followerID, limit, offset)
+	followeeIDs, total, err := s.followRepo.GetFollowees(ctx, followerID, limit, offset)
 	if err != nil {
 		s.log.Error("Error getting followees", slog.String("error", err.Error()))
-		return nil, err
+		return nil, 0, err
 	}
 
-	s.log.Info("Followees retrieved successfully", slog.Int64("followerID", followerID), slog.Int("count", len(followees)))
-	return followees, nil
+	// Получаем информацию о пользователях по их ID
+	followees := make([]*model.User, 0, len(followeeIDs))
+	for _, followeeID := range followeeIDs {
+		user, err := s.userClient.GetUser(ctx, followeeID)
+		if err != nil {
+			s.log.Error("Failed to get followee user", slog.Int64("followeeID", followeeID), slog.String("error", err.Error()))
+			// Пропускаем пользователей, которых не удалось получить
+			continue
+		}
+		followees = append(followees, user)
+	}
+
+	s.log.Info("Followees retrieved successfully", slog.Int64("followerID", followerID), slog.Int("count", len(followees)), slog.Int64("total", total))
+	return followees, total, nil
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -160,13 +160,11 @@ func (s *Service) GetFollowers(ctx context.Context, followeeID int64, limit, pag
 		return nil, 0, err
 	}
 
-	// Получаем информацию о пользователях по их ID
 	followers := make([]*model.User, 0, len(followerIDs))
 	for _, followerID := range followerIDs {
 		user, err := s.userClient.GetUser(ctx, followerID)
 		if err != nil {
 			s.log.Error("Failed to get follower user", slog.Int64("followerID", followerID), slog.String("error", err.Error()))
-			// Пропускаем пользователей, которых не удалось получить
 			continue
 		}
 		followers = append(followers, user)
@@ -196,13 +194,11 @@ func (s *Service) GetFollowees(ctx context.Context, followerID int64, limit, pag
 		return nil, 0, err
 	}
 
-	// Получаем информацию о пользователях по их ID
 	followees := make([]*model.User, 0, len(followeeIDs))
 	for _, followeeID := range followeeIDs {
 		user, err := s.userClient.GetUser(ctx, followeeID)
 		if err != nil {
 			s.log.Error("Failed to get followee user", slog.Int64("followeeID", followeeID), slog.String("error", err.Error()))
-			// Пропускаем пользователей, которых не удалось получить
 			continue
 		}
 		followees = append(followees, user)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -322,7 +322,6 @@ func TestService_GetFollowers(t *testing.T) {
 
 		mockFollowRepo.On("GetFollowers", ctx, followeeID, limit, int32(0)).Return(expectedFollowerIDs, expectedTotal, nil)
 
-		// Мокаем получение пользователей по их ID
 		for _, followerID := range expectedFollowerIDs {
 			mockUserClient.On("GetUser", ctx, followerID).Return(&model.User{ID: followerID}, nil)
 		}
@@ -407,7 +406,6 @@ func TestService_GetFollowers(t *testing.T) {
 
 		mockFollowRepo.On("GetFollowers", ctx, followeeID, limit, int32(0)).Return(expectedFollowerIDs, expectedTotal, nil)
 
-		// Мокаем получение пользователей по их ID - один пользователь не найден
 		mockUserClient.On("GetUser", ctx, int64(1)).Return(&model.User{ID: 1}, nil)
 		mockUserClient.On("GetUser", ctx, int64(3)).Return(nil, custom_errors.ErrUserNotFound) // Пользователь удален
 		mockUserClient.On("GetUser", ctx, int64(5)).Return(&model.User{ID: 5}, nil)
@@ -415,7 +413,7 @@ func TestService_GetFollowers(t *testing.T) {
 		followers, total, err := svc.GetFollowers(ctx, followeeID, limit, page)
 
 		require.NoError(t, err)
-		assert.Len(t, followers, 2) // Только 2 пользователя, так как один был не найден
+		assert.Len(t, followers, 2)
 		assert.Equal(t, expectedTotal, total)
 		assert.Equal(t, int64(1), followers[0].ID)
 		assert.Equal(t, int64(5), followers[1].ID)
@@ -437,7 +435,6 @@ func TestService_GetFollowees(t *testing.T) {
 
 		mockFollowRepo.On("GetFollowees", ctx, followerID, limit, int32(0)).Return(expectedFolloweeIDs, expectedTotal, nil)
 
-		// Мокаем получение пользователей по их ID
 		for _, followeeID := range expectedFolloweeIDs {
 			mockUserClient.On("GetUser", ctx, followeeID).Return(&model.User{ID: followeeID}, nil)
 		}
@@ -522,7 +519,6 @@ func TestService_GetFollowees(t *testing.T) {
 
 		mockFollowRepo.On("GetFollowees", ctx, followerID, limit, int32(0)).Return(expectedFolloweeIDs, expectedTotal, nil)
 
-		// Мокаем получение пользователей по их ID - один пользователь не найден
 		mockUserClient.On("GetUser", ctx, int64(2)).Return(&model.User{ID: 2}, nil)
 		mockUserClient.On("GetUser", ctx, int64(4)).Return(nil, custom_errors.ErrUserNotFound) // Пользователь удален
 		mockUserClient.On("GetUser", ctx, int64(6)).Return(&model.User{ID: 6}, nil)
@@ -530,7 +526,7 @@ func TestService_GetFollowees(t *testing.T) {
 		followees, total, err := svc.GetFollowees(ctx, followerID, limit, page)
 
 		require.NoError(t, err)
-		assert.Len(t, followees, 2) // Только 2 пользователя, так как один был не найден
+		assert.Len(t, followees, 2)
 		assert.Equal(t, expectedTotal, total)
 		assert.Equal(t, int64(2), followees[0].ID)
 		assert.Equal(t, int64(6), followees[1].ID)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -12,3 +12,8 @@ func SetPaginationDefaults(limit, page int32) (int32, int32) {
 	offset := (page - 1) * limit
 	return limit, offset
 }
+
+// Helper function to create string pointer
+func StringPtr(s string) *string {
+	return &s
+}

--- a/mocks/follow_repository.go
+++ b/mocks/follow_repository.go
@@ -187,7 +187,7 @@ func (_c *FollowRepository_Exists_Call) RunAndReturn(run func(context.Context, i
 }
 
 // GetFollowees provides a mock function with given fields: ctx, followerID, limit, offset
-func (_m *FollowRepository) GetFollowees(ctx context.Context, followerID int64, limit int32, offset int32) ([]int64, error) {
+func (_m *FollowRepository) GetFollowees(ctx context.Context, followerID int64, limit int32, offset int32) ([]int64, int64, error) {
 	ret := _m.Called(ctx, followerID, limit, offset)
 
 	if len(ret) == 0 {
@@ -195,8 +195,9 @@ func (_m *FollowRepository) GetFollowees(ctx context.Context, followerID int64, 
 	}
 
 	var r0 []int64
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) ([]int64, error)); ok {
+	var r1 int64
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) ([]int64, int64, error)); ok {
 		return rf(ctx, followerID, limit, offset)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) []int64); ok {
@@ -207,13 +208,19 @@ func (_m *FollowRepository) GetFollowees(ctx context.Context, followerID int64, 
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, int32, int32) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int32, int32) int64); ok {
 		r1 = rf(ctx, followerID, limit, offset)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int64)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, int64, int32, int32) error); ok {
+		r2 = rf(ctx, followerID, limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // FollowRepository_GetFollowees_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFollowees'
@@ -237,18 +244,18 @@ func (_c *FollowRepository_GetFollowees_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *FollowRepository_GetFollowees_Call) Return(_a0 []int64, _a1 error) *FollowRepository_GetFollowees_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *FollowRepository_GetFollowees_Call) Return(_a0 []int64, _a1 int64, _a2 error) *FollowRepository_GetFollowees_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *FollowRepository_GetFollowees_Call) RunAndReturn(run func(context.Context, int64, int32, int32) ([]int64, error)) *FollowRepository_GetFollowees_Call {
+func (_c *FollowRepository_GetFollowees_Call) RunAndReturn(run func(context.Context, int64, int32, int32) ([]int64, int64, error)) *FollowRepository_GetFollowees_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetFollowers provides a mock function with given fields: ctx, followeeID, limit, offset
-func (_m *FollowRepository) GetFollowers(ctx context.Context, followeeID int64, limit int32, offset int32) ([]int64, error) {
+func (_m *FollowRepository) GetFollowers(ctx context.Context, followeeID int64, limit int32, offset int32) ([]int64, int64, error) {
 	ret := _m.Called(ctx, followeeID, limit, offset)
 
 	if len(ret) == 0 {
@@ -256,8 +263,9 @@ func (_m *FollowRepository) GetFollowers(ctx context.Context, followeeID int64, 
 	}
 
 	var r0 []int64
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) ([]int64, error)); ok {
+	var r1 int64
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) ([]int64, int64, error)); ok {
 		return rf(ctx, followeeID, limit, offset)
 	}
 	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) []int64); ok {
@@ -268,13 +276,19 @@ func (_m *FollowRepository) GetFollowers(ctx context.Context, followeeID int64, 
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, int32, int32) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int32, int32) int64); ok {
 		r1 = rf(ctx, followeeID, limit, offset)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int64)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, int64, int32, int32) error); ok {
+		r2 = rf(ctx, followeeID, limit, offset)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // FollowRepository_GetFollowers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFollowers'
@@ -298,12 +312,12 @@ func (_c *FollowRepository_GetFollowers_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *FollowRepository_GetFollowers_Call) Return(_a0 []int64, _a1 error) *FollowRepository_GetFollowers_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *FollowRepository_GetFollowers_Call) Return(_a0 []int64, _a1 int64, _a2 error) *FollowRepository_GetFollowers_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *FollowRepository_GetFollowers_Call) RunAndReturn(run func(context.Context, int64, int32, int32) ([]int64, error)) *FollowRepository_GetFollowers_Call {
+func (_c *FollowRepository_GetFollowers_Call) RunAndReturn(run func(context.Context, int64, int32, int32) ([]int64, int64, error)) *FollowRepository_GetFollowers_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/follow_service.go
+++ b/mocks/follow_service.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	context "context"
+	model "pinstack-relation-service/internal/model"
 
 	mock "github.com/stretchr/testify/mock"
 )
@@ -70,33 +71,40 @@ func (_c *FollowService_Follow_Call) RunAndReturn(run func(context.Context, int6
 }
 
 // GetFollowees provides a mock function with given fields: ctx, followerID, limit, page
-func (_m *FollowService) GetFollowees(ctx context.Context, followerID int64, limit int32, page int32) ([]int64, error) {
+func (_m *FollowService) GetFollowees(ctx context.Context, followerID int64, limit int32, page int32) ([]*model.User, int64, error) {
 	ret := _m.Called(ctx, followerID, limit, page)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFollowees")
 	}
 
-	var r0 []int64
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) ([]int64, error)); ok {
+	var r0 []*model.User
+	var r1 int64
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) ([]*model.User, int64, error)); ok {
 		return rf(ctx, followerID, limit, page)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) []int64); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) []*model.User); ok {
 		r0 = rf(ctx, followerID, limit, page)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]int64)
+			r0 = ret.Get(0).([]*model.User)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, int32, int32) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int32, int32) int64); ok {
 		r1 = rf(ctx, followerID, limit, page)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int64)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, int64, int32, int32) error); ok {
+		r2 = rf(ctx, followerID, limit, page)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // FollowService_GetFollowees_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFollowees'
@@ -120,44 +128,51 @@ func (_c *FollowService_GetFollowees_Call) Run(run func(ctx context.Context, fol
 	return _c
 }
 
-func (_c *FollowService_GetFollowees_Call) Return(_a0 []int64, _a1 error) *FollowService_GetFollowees_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *FollowService_GetFollowees_Call) Return(_a0 []*model.User, _a1 int64, _a2 error) *FollowService_GetFollowees_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *FollowService_GetFollowees_Call) RunAndReturn(run func(context.Context, int64, int32, int32) ([]int64, error)) *FollowService_GetFollowees_Call {
+func (_c *FollowService_GetFollowees_Call) RunAndReturn(run func(context.Context, int64, int32, int32) ([]*model.User, int64, error)) *FollowService_GetFollowees_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetFollowers provides a mock function with given fields: ctx, followeeID, limit, page
-func (_m *FollowService) GetFollowers(ctx context.Context, followeeID int64, limit int32, page int32) ([]int64, error) {
+func (_m *FollowService) GetFollowers(ctx context.Context, followeeID int64, limit int32, page int32) ([]*model.User, int64, error) {
 	ret := _m.Called(ctx, followeeID, limit, page)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFollowers")
 	}
 
-	var r0 []int64
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) ([]int64, error)); ok {
+	var r0 []*model.User
+	var r1 int64
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) ([]*model.User, int64, error)); ok {
 		return rf(ctx, followeeID, limit, page)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) []int64); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, int64, int32, int32) []*model.User); ok {
 		r0 = rf(ctx, followeeID, limit, page)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]int64)
+			r0 = ret.Get(0).([]*model.User)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int64, int32, int32) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, int64, int32, int32) int64); ok {
 		r1 = rf(ctx, followeeID, limit, page)
 	} else {
-		r1 = ret.Error(1)
+		r1 = ret.Get(1).(int64)
 	}
 
-	return r0, r1
+	if rf, ok := ret.Get(2).(func(context.Context, int64, int32, int32) error); ok {
+		r2 = rf(ctx, followeeID, limit, page)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // FollowService_GetFollowers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetFollowers'
@@ -181,12 +196,12 @@ func (_c *FollowService_GetFollowers_Call) Run(run func(ctx context.Context, fol
 	return _c
 }
 
-func (_c *FollowService_GetFollowers_Call) Return(_a0 []int64, _a1 error) *FollowService_GetFollowers_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *FollowService_GetFollowers_Call) Return(_a0 []*model.User, _a1 int64, _a2 error) *FollowService_GetFollowers_Call {
+	_c.Call.Return(_a0, _a1, _a2)
 	return _c
 }
 
-func (_c *FollowService_GetFollowers_Call) RunAndReturn(run func(context.Context, int64, int32, int32) ([]int64, error)) *FollowService_GetFollowers_Call {
+func (_c *FollowService_GetFollowers_Call) RunAndReturn(run func(context.Context, int64, int32, int32) ([]*model.User, int64, error)) *FollowService_GetFollowers_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This pull request introduces significant changes to the `pinstack-relation-service` to enhance the functionality of fetching followers and followees, including pagination and user details. The updates involve modifying the data model, updating the repository and service layers, and extending the gRPC handlers and their corresponding tests.

### Enhancements to Followers and Followees Retrieval:

* **Data Model Updates:**
  - Updated the `FollowRepository` interface to return both user details (`*model.User`) and the total count for followers and followees queries. (`internal/repository/interface.go`, [internal/repository/interface.goL13-R14](diffhunk://#diff-60d25304d3c321542e6951199a6dc7824ac41ad03c7c1d2f3cf775d7ceab31b4L13-R14))

* **Repository Layer:**
  - Modified the `GetFollowers` and `GetFollowees` methods in the PostgreSQL repository to include a query for the total count of records, ensuring accurate pagination. (`internal/repository/postgres/repository.go`, [[1]](diffhunk://#diff-e88ed7a8f18a208f230584dc9202e5ccd76bde6d3fa44ebc7a8a3beafb96d60dL94-R116) [[2]](diffhunk://#diff-e88ed7a8f18a208f230584dc9202e5ccd76bde6d3fa44ebc7a8a3beafb96d60dL116-R136) [[3]](diffhunk://#diff-e88ed7a8f18a208f230584dc9202e5ccd76bde6d3fa44ebc7a8a3beafb96d60dL127-R147)

### Updates to gRPC Handlers:

* **GetFolloweesHandler:**
  - Updated the `FolloweesGetter` interface and gRPC handler to return detailed user information (`*model.User`) and the total count of followees. (`internal/delivery/grpc/get_followees_handler.go`, [[1]](diffhunk://#diff-9136ae421d6344f3831d19ac9be19aaac24dc0e66cebd1b9e1b0d0a669984f3bL16-R17) [[2]](diffhunk://#diff-9136ae421d6344f3831d19ac9be19aaac24dc0e66cebd1b9e1b0d0a669984f3bL49-R50)
  - Transformed the response to include a list of `pb.User` objects with `FollowerId`, `Username`, and optional `AvatarUrl`. (`internal/delivery/grpc/get_followees_handler.go`, [internal/delivery/grpc/get_followees_handler.goR62-R76](diffhunk://#diff-9136ae421d6344f3831d19ac9be19aaac24dc0e66cebd1b9e1b0d0a669984f3bR62-R76))

* **GetFollowersHandler:**
  - Updated the `FollowersGetter` interface and gRPC handler similarly to return detailed user information and the total count of followers. (`internal/delivery/grpc/get_followers_handler.go`, [[1]](diffhunk://#diff-9987994e1bcd82ff7a9670d87f2153e244c0781e546441fa8748927b373abdf7L16-R17) [[2]](diffhunk://#diff-9987994e1bcd82ff7a9670d87f2153e244c0781e546441fa8748927b373abdf7L49-R50)
  - Adjusted the response structure to include a list of `pb.User` objects. (`internal/delivery/grpc/get_followers_handler.go`, [internal/delivery/grpc/get_followers_handler.goR62-R76](diffhunk://#diff-9987994e1bcd82ff7a9670d87f2153e244c0781e546441fa8748927b373abdf7R62-R76))

### Test Enhancements:

* **Followees Tests:**
  - Updated the `GetFolloweesHandler` test cases to validate the new response structure, including user details and total count. (`internal/delivery/grpc/get_followees_handler_test.go`, [[1]](diffhunk://#diff-c95cb108baf7abdd358a8e955465b02c87ed75e341a14d597dbcf2b552622792L29-R32) [[2]](diffhunk://#diff-c95cb108baf7abdd358a8e955465b02c87ed75e341a14d597dbcf2b552622792R42-R56) [[3]](diffhunk://#diff-c95cb108baf7abdd358a8e955465b02c87ed75e341a14d597dbcf2b552622792L176-R201)

* **Followers Tests:**
  - Similarly updated the `GetFollowersHandler` test cases to ensure the correctness of the new response format. (`internal/delivery/grpc/get_followers_handler_test.go`, [[1]](diffhunk://#diff-604c258b1f95687d798f3e5dacbe1a7a6e00157beba69beb2977ee1ac9bc6d08L29-R32) [[2]](diffhunk://#diff-604c258b1f95687d798f3e5dacbe1a7a6e00157beba69beb2977ee1ac9bc6d08R42-R56) [[3]](diffhunk://#diff-604c258b1f95687d798f3e5dacbe1a7a6e00157beba69beb2977ee1ac9bc6d08L176-R201)

### Dependency Updates:

* Updated the `pinstack-proto-definitions` dependency in `go.mod` to version `v0.1.19`, which likely includes the updated protobuf definitions for the new response structures. (`go.mod`, [go.modL12-R12](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L12-R12))