### PR TITLE
ci: update Makefile and CI configuration for relation service integra…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
 
     - name: Start Full Infrastructure for Integration Tests
       working-directory: pinstack-system-tests
+      env:
+        RELATION_SERVICE_CONTEXT: ../
       run: |
         # Запускаем все необходимые контейнеры для интеграционных тестов
         docker compose -f docker-compose.test.yml up -d \
@@ -112,6 +114,8 @@ jobs:
         # Ждем готовности баз данных
         timeout 60 bash -c 'until docker exec pinstack-user-db-test pg_isready -U postgres; do sleep 2; done'
         timeout 60 bash -c 'until docker exec pinstack-auth-db-test pg_isready -U postgres; do sleep 2; done'
+        timeout 60 bash -c 'until docker exec pinstack-relation-db-test pg_isready -U postgres; do sleep 2; done'
+        timeout 60 bash -c 'until docker exec pinstack-notification-db-test pg_isready -U postgres; do sleep 2; done'
         
         # Ждем готовности всех сервисов
         sleep 60

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test-unit: check-go-version
 start-relation-infrastructure: setup-system-tests
 	@echo "🚀 Запуск полной инфраструктуры для интеграционных тестов..."
 	cd $(SYSTEM_TESTS_DIR) && \
-	docker compose -f docker-compose.test.yml up -d \
+	RELATION_SERVICE_CONTEXT=../pinstack-relation-service docker compose -f docker-compose.test.yml up -d \
 		user-db-test \
 		user-migrator-test \
 		user-service-test \
@@ -78,6 +78,8 @@ check-services:
 	@docker logs pinstack-relation-service-test --tail=10
 	@echo "=== API Gateway logs ==="
 	@docker logs pinstack-api-gateway-test --tail=10
+	@echo "=== Kafka logs ==="
+	@docker logs pinstack-kafka-test --tail=5
 
 # Интеграционные тесты только для relation service
 test-relation-integration: start-relation-infrastructure check-services
@@ -181,6 +183,21 @@ logs-db:
 logs-auth-db:
 	cd $(SYSTEM_TESTS_DIR) && \
 	docker compose -f docker-compose.test.yml logs -f auth-db-test
+
+# Быстрый тест с локальным relation-service
+quick-test-local: setup-system-tests
+	@echo "⚡ Быстрый запуск тестов с локальным relation-service..."
+	cd $(SYSTEM_TESTS_DIR) && \
+	RELATION_SERVICE_CONTEXT=../pinstack-relation-service docker compose -f docker-compose.test.yml up -d \
+		user-db-test user-migrator-test user-service-test \
+		auth-db-test auth-migrator-test auth-service-test \
+		api-gateway-test notification-db-test notification-migrator-test notification-service-test \
+		kafka-test kafka-topics-init-test relation-db-test relation-migrator-test relation-service-test
+	@echo "⏳ Ожидание готовности сервисов..."
+	@sleep 30
+	cd $(SYSTEM_TESTS_DIR) && \
+	go test -v -count=1 -timeout=5m ./internal/scenarios/integration/gateway_relation/...
+	$(MAKE) stop-relation-infrastructure
 
 # Очистка
 clean: clean-relation-infrastructure


### PR DESCRIPTION
This pull request updates the integration test infrastructure for the relation service, improving environment consistency and test reliability. The main changes involve ensuring required environment variables are set, adding readiness checks for new database services, and enhancing logging and test commands in the `Makefile`.

**Infrastructure and environment setup:**
* Added the `RELATION_SERVICE_CONTEXT` environment variable to both the CI workflow and `Makefile` commands to ensure the relation service context is correctly set during integration test runs (`.github/workflows/ci.yml`, `Makefile`). [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR89-R90) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L44-R44)

**Database readiness checks:**
* Included readiness checks for `pinstack-relation-db-test` and `pinstack-notification-db-test` in the CI workflow to make sure these databases are available before starting tests (`.github/workflows/ci.yml`).

**Logging improvements:**
* Added Kafka logs to the `Makefile` service check command to provide better visibility into Kafka test container status (`Makefile`).

**Testing commands:**
* Introduced a new `quick-test-local` target in the `Makefile` for fast local integration testing with the relation service, including setup, service startup, and test execution (`Makefile`).…tion tests